### PR TITLE
Fix #8: Android Gradle Plugin 7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,18 @@ jobs:
           assemble
           check
           violationReportHtml
+          violationCountFile
+
+      - name: Fail if there are violations
+        run: |
+          count=$(cat "${{ github.workspace }}/build/reports/violations.count")
+          if [[ "$count" != "0" ]]; then
+            echo "There were $count violations"
+            exit 1
+          else
+            echo "No violations found."
+            exit 0
+          fi
 
       - name: Upload "Unit Test Results".
         if: success() || failure()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,6 +13,6 @@ dependencies {
 android {
 	defaultConfig {
 		applicationId = "net.twisterrob.sun"
-		targetSdkVersion(Deps.Android.targetSdkVersion)
+		targetSdk = Deps.Android.targetSdkVersion
 	}
 }

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,8 +1,10 @@
 <lint>
 
 	<issue id="UnusedResources">
-		<ignore regexp="R\.bool\.in_prod" />
-		<ignore regexp="R\.bool\.in_test" />
+
+		<!-- False positive, it is used by lower modules, and auto-generated in app, the merger will use it. -->
+		<ignore regexp="R\.string\.app_package" />
+
 	</issue>
 
 </lint>

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -3,7 +3,7 @@
 	<issue id="UnusedResources">
 
 		<!-- False positive, it is used by lower modules, and auto-generated in app, the merger will use it. -->
-		<ignore regexp="R\.string\.app_package" />
+<!--		<ignore regexp="R\.string\.app_package" />-->
 
 	</issue>
 

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -3,7 +3,7 @@
 	<issue id="UnusedResources">
 
 		<!-- False positive, it is used by lower modules, and auto-generated in app, the merger will use it. -->
-<!--		<ignore regexp="R\.string\.app_package" />-->
+		<ignore regexp="R\.string\.app_package" />
 
 	</issue>
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
 	id("com.android.application") version "7.0.4" apply false
 	id("app.cash.paparazzi") version "0.8.0" apply false
-	id("net.twisterrob.root") version "0.13-SNAPSHOT"
-	id("net.twisterrob.quality") version "0.13-SNAPSHOT"
+	id("net.twisterrob.root") version "0.13.fix195-SNAPSHOT"
+	id("net.twisterrob.quality") version "0.13.fix195-SNAPSHOT"
 	id("project-dependencies") apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
 	// TODEL ObsoleteLintCustomCheck once on 7.x
 	id("com.android.application") version "4.2.2" apply false
 	id("app.cash.paparazzi") version "0.8.0" apply false
-	id("net.twisterrob.root") version "0.12"
-	id("net.twisterrob.quality") version "0.12"
+	id("net.twisterrob.root") version "0.13-SNAPSHOT"
+	id("net.twisterrob.quality") version "0.13-SNAPSHOT"
 	id("project-dependencies") apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
 	// TODEL ObsoleteLintCustomCheck once on 7.x
-	id("com.android.application") version "4.2.2" apply false
+	id("com.android.application") version "7.0.4" apply false
 	id("app.cash.paparazzi") version "0.8.0" apply false
 	id("net.twisterrob.root") version "0.13-SNAPSHOT"
 	id("net.twisterrob.quality") version "0.13-SNAPSHOT"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-	// TODEL ObsoleteLintCustomCheck once on 7.x
 	id("com.android.application") version "7.0.4" apply false
 	id("app.cash.paparazzi") version "0.8.0" apply false
 	id("net.twisterrob.root") version "0.13-SNAPSHOT"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
 	id("com.android.application") version "7.0.4" apply false
 	id("app.cash.paparazzi") version "0.8.0" apply false
-	id("net.twisterrob.root") version "0.13.fix195-SNAPSHOT"
-	id("net.twisterrob.quality") version "0.13.fix195-SNAPSHOT"
+	id("net.twisterrob.root") version "0.13"
+	id("net.twisterrob.quality") version "0.13"
 	id("project-dependencies") apply false
 }

--- a/component/widget/src/main/AndroidManifest.xml
+++ b/component/widget/src/main/AndroidManifest.xml
@@ -10,7 +10,10 @@
 
 	<application>
 
-		<receiver android:name="net.twisterrob.sun.android.SunAngleWidgetProvider">
+		<receiver
+			android:name="net.twisterrob.sun.android.SunAngleWidgetProvider"
+			android:exported="true"
+			>
 			<intent-filter>
 				<action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
 			</intent-filter>

--- a/component/widget/src/main/java/net/twisterrob/sun/android/logic/SunAngleWidgetView.java
+++ b/component/widget/src/main/java/net/twisterrob/sun/android/logic/SunAngleWidgetView.java
@@ -7,6 +7,7 @@ import java.util.EnumMap;
 import java.util.Locale;
 import java.util.Map;
 
+import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
 import android.content.Context;
@@ -173,7 +174,9 @@ public class SunAngleWidgetView {
 			Class<?> SAWC = Class.forName("net.twisterrob.sun.android.SunAngleWidgetConfiguration");
 			Intent configIntent = new Intent(context, SAWC);
 			configIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
-			return PendingIntent.getActivity(context, appWidgetId, configIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+			@SuppressLint("InlinedApi") // New flag shouldn't cause a problem in older versions.
+			int flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
+			return PendingIntent.getActivity(context, appWidgetId, configIntent, flags);
 		} catch (ClassNotFoundException e) {
 			throw new IllegalStateException("Missing configuration activity.");
 		}
@@ -181,7 +184,9 @@ public class SunAngleWidgetView {
 
 	protected static @NonNull PendingIntent createRefreshIntent(@NonNull Context context, int appWidgetId) {
 		Intent intent = createUpdateIntent(context, appWidgetId);
-		return PendingIntent.getBroadcast(context, appWidgetId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+		@SuppressLint("InlinedApi") // New flag shouldn't cause a problem in older versions.
+		int flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
+		return PendingIntent.getBroadcast(context, appWidgetId, intent, flags);
 	}
 
 	protected static @NonNull  Intent createUpdateIntent(@NonNull Context context, @NonNull int... appWidgetIds) {

--- a/config/lint/baseline/lint_baseline-app.xml
+++ b/config/lint/baseline/lint_baseline-app.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="5" by="lint 4.2.2" client="gradle" variant="all" version="4.2.2">
+<issues format="6" by="lint 7.0.4" type="baseline" client="gradle" name="AGP (7.0.4)" variant="all" version="7.0.4">
 
 </issues>

--- a/config/lint/baseline/lint_baseline-component+states.xml
+++ b/config/lint/baseline/lint_baseline-component+states.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="5" by="lint 4.2.2" client="gradle" variant="all" version="4.2.2">
+<issues format="6" by="lint 7.0.4" type="baseline" client="gradle" name="AGP (7.0.4)" variant="all" version="7.0.4">
 
 </issues>

--- a/config/lint/baseline/lint_baseline-component+theme.xml
+++ b/config/lint/baseline/lint_baseline-component+theme.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="5" by="lint 4.2.2" client="gradle" variant="all" version="4.2.2">
+<issues format="6" by="lint 7.0.4" type="baseline" client="gradle" name="AGP (7.0.4)" variant="all" version="7.0.4">
 
 </issues>

--- a/config/lint/baseline/lint_baseline-component+widget.xml
+++ b/config/lint/baseline/lint_baseline-component+widget.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="5" by="lint 4.2.2" client="gradle" variant="all" version="4.2.2">
+<issues format="6" by="lint 7.0.4" type="baseline" client="gradle" name="AGP (7.0.4)" variant="all" version="7.0.4">
 
     <issue
         id="StaticFieldLeak"

--- a/config/lint/baseline/lint_baseline-feature+configuration.xml
+++ b/config/lint/baseline/lint_baseline-feature+configuration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="5" by="lint 4.2.2" client="gradle" variant="all" version="4.2.2">
+<issues format="6" by="lint 7.0.4" type="baseline" client="gradle" name="AGP (7.0.4)" variant="all" version="7.0.4">
 
     <issue
         id="ClickableViewAccessibility"

--- a/config/lint/baseline/lint_baseline-feature+preview.xml
+++ b/config/lint/baseline/lint_baseline-feature+preview.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="5" by="lint 4.2.2" client="gradle" variant="all" version="4.2.2">
+<issues format="6" by="lint 7.0.4" type="baseline" client="gradle" name="AGP (7.0.4)" variant="all" version="7.0.4">
 
     <issue
         id="RtlEnabled"

--- a/feature/configuration/src/main/AndroidManifest.xml
+++ b/feature/configuration/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
 		<activity
 			android:name="net.twisterrob.sun.android.SunAngleWidgetConfiguration"
 			android:label="@string/config_title"
-			android:exported="false"
+			android:exported="true"
 			>
 			<intent-filter>
 				<action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />

--- a/feature/configuration/src/main/AndroidManifest.xml
+++ b/feature/configuration/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
 		<activity
 			android:name="net.twisterrob.sun.android.SunAngleWidgetConfiguration"
 			android:label="@string/config_title"
+			android:exported="false"
 			>
 			<intent-filter>
 				<action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />

--- a/feature/preview/src/main/AndroidManifest.xml
+++ b/feature/preview/src/main/AndroidManifest.xml
@@ -7,7 +7,9 @@
 		<activity
 			android:name="net.twisterrob.sun.android.WidgetScreenshotActivity"
 			android:label="Sun Position Widget Preview"
-			android:enabled="@bool/in_test">
+			android:enabled="@bool/in_test"
+			android:exported="true"
+			>
 			<intent-filter android:label="Sun Preview">
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
@@ -19,7 +21,8 @@
 			android:authorities="@string/app_package"
 			android:enabled="@bool/in_test"
 			android:exported="false"
-			android:grantUriPermissions="true">
+			android:grantUriPermissions="true"
+			>
 			<meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/paths_screenshot" />
 		</provider>
 

--- a/feature/preview/src/main/java/net/twisterrob/sun/android/WidgetScreenshotActivity.java
+++ b/feature/preview/src/main/java/net/twisterrob/sun/android/WidgetScreenshotActivity.java
@@ -28,6 +28,8 @@ import net.twisterrob.sun.algo.SunSearchResults.ThresholdRelation;
 import net.twisterrob.sun.preview.R;
 
 public class WidgetScreenshotActivity extends Activity {
+	private static final String TAG = "WidgetScreenshot";
+
 	private AppWidgetManager manager;
 	private AppWidgetHost host;
 	private ViewGroup layout;
@@ -154,7 +156,13 @@ public class WidgetScreenshotActivity extends Activity {
 
 	private void resetView(int appWidgetId) {
 		AppWidgetProviderInfo info = manager.getAppWidgetInfo(appWidgetId);
+		if (info == null) {
+			Log.w(TAG, "Cannot get widget info for " + appWidgetId);
+		}
 		AppWidgetHostView hostView = host.createView(getApplicationContext(), appWidgetId, info);
+		if (hostView == null) {
+			Log.w(TAG, host + " failed to create widget view for " + appWidgetId);
+		}
 		layout.removeAllViews();
 		layout.addView(hostView);
 		updateSize();

--- a/gradle/dependencies/build.gradle.kts
+++ b/gradle/dependencies/build.gradle.kts
@@ -17,7 +17,3 @@ gradlePlugin {
 		implementationClass = "net.twisterrob.sun.dependencies.DependenciesPlugin"
 	}
 }
-
-kotlinDslPluginOptions {
-	experimentalWarning.set(false)
-}

--- a/gradle/dependencies/gradle.properties
+++ b/gradle/dependencies/gradle.properties
@@ -1,0 +1,3 @@
+# TODEL https://github.com/gradle/gradle/issues/18935#issuecomment-974251717
+# Need this fixed: https://youtrack.jetbrains.com/issue/KT-48745
+kotlin.jvm.target.validation.mode=IGNORE

--- a/gradle/dependencies/src/main/kotlin/Deps.kt
+++ b/gradle/dependencies/src/main/kotlin/Deps.kt
@@ -15,7 +15,7 @@ object Deps {
 		 */
 		const val targetSdkVersion = 19
 
-		const val plugin = "com.android.tools.build:gradle:4.2.2"
+		const val plugin = "com.android.tools.build:gradle:7.0.4"
 		const val cacheFix = "gradle.plugin.org.gradle.android:android-cache-fix-gradle-plugin:2.4.5"
 	}
 

--- a/gradle/dependencies/src/main/kotlin/Deps.kt
+++ b/gradle/dependencies/src/main/kotlin/Deps.kt
@@ -16,7 +16,7 @@ object Deps {
 		const val targetSdkVersion = 19
 
 		const val plugin = "com.android.tools.build:gradle:4.2.2"
-		const val cacheFix = "gradle.plugin.org.gradle.android:android-cache-fix-gradle-plugin:2.4.4"
+		const val cacheFix = "gradle.plugin.org.gradle.android:android-cache-fix-gradle-plugin:2.4.5"
 	}
 
 	object AndroidX {

--- a/gradle/dependencies/src/main/kotlin/Deps.kt
+++ b/gradle/dependencies/src/main/kotlin/Deps.kt
@@ -15,6 +15,9 @@ object Deps {
 		 */
 		const val targetSdkVersion = 19
 
+		/**
+		 * TODEL 211012777 when updating from 7.0
+		 */
 		const val plugin = "com.android.tools.build:gradle:7.0.4"
 		const val cacheFix = "gradle.plugin.org.gradle.android:android-cache-fix-gradle-plugin:2.4.5"
 	}

--- a/gradle/plugins/build.gradle.kts
+++ b/gradle/plugins/build.gradle.kts
@@ -30,7 +30,3 @@ gradlePlugin {
 		implementationClass = "net.twisterrob.sun.plugins.PaparazziPlugin"
 	}
 }
-
-kotlinDslPluginOptions {
-	experimentalWarning.set(false)
-}

--- a/gradle/plugins/gradle.properties
+++ b/gradle/plugins/gradle.properties
@@ -1,0 +1,3 @@
+# TODEL https://github.com/gradle/gradle/issues/18935#issuecomment-974251717
+# Need this fixed: https://youtrack.jetbrains.com/issue/KT-48745
+kotlin.jvm.target.validation.mode=IGNORE

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/sun/plugins/commonAndroidConfig.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/sun/plugins/commonAndroidConfig.kt
@@ -2,8 +2,11 @@ package net.twisterrob.sun.plugins
 
 import Deps
 import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.internal.lint.AndroidLintTask
 import org.gradle.api.Project
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
 
 internal fun Project.commonAndroidConfig() {
 	// TODO https://github.com/gradle/android-cache-fix-gradle-plugin/issues/215
@@ -17,6 +20,12 @@ internal fun Project.commonAndroidConfig() {
 			xmlReport = true
 			val projectSlug = project.path.substringAfter(':').replace(":", "+")
 			baseline(rootProject.file("config/lint/baseline/lint_baseline-${projectSlug}.xml"))
+		}
+
+		// TODEL https://issuetracker.google.com/issues/211012777
+		project.tasks.withType<AndroidLintTask>().configureEach {
+			this.inputs.files(rootProject.file("lint.xml")).withPathSensitivity(PathSensitivity.RELATIVE)
+			this.inputs.files(project.file("lint.xml")).withPathSensitivity(PathSensitivity.RELATIVE)
 		}
 	}
 }

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/sun/plugins/commonAndroidConfig.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/sun/plugins/commonAndroidConfig.kt
@@ -11,7 +11,7 @@ internal fun Project.commonAndroidConfig() {
 	extensions.configure<BaseExtension> {
 		compileSdkVersion(Deps.Android.compileSdkVersion)
 		defaultConfig {
-			minSdkVersion(Deps.Android.minSdkVersion)
+			minSdk = Deps.Android.minSdkVersion
 		}
 		lintOptions {
 			xmlReport = true

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/sun/plugins/commonAndroidConfig.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/sun/plugins/commonAndroidConfig.kt
@@ -3,11 +3,11 @@ package net.twisterrob.sun.plugins
 import Deps
 import com.android.build.gradle.BaseExtension
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 
 internal fun Project.commonAndroidConfig() {
-	apply(plugin = "org.gradle.android.cache-fix")
+	// TODO https://github.com/gradle/android-cache-fix-gradle-plugin/issues/215
+	//apply(plugin = "org.gradle.android.cache-fix")
 	extensions.configure<BaseExtension> {
 		compileSdkVersion(Deps.Android.compileSdkVersion)
 		defaultConfig {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lint.xml
+++ b/lint.xml
@@ -10,6 +10,11 @@
 	<issue id="UnusedResources">
 		<!-- Used by *ScreenshotTest via PaparazziCoat. -->
 		<ignore regexp="`R.style.AppTheme_ScreenshotTest`" />
+
+		<!-- Auto-generated -->
+		<ignore regexp="R\.bool\.in_prod" />
+		<ignore regexp="R\.bool\.in_test" />
+
 	</issue>
 
 </lint>

--- a/lint.xml
+++ b/lint.xml
@@ -7,14 +7,6 @@
 	<issue id="UnknownNullness" severity="ignore" />
 	<issue id="SyntheticAccessor" severity="ignore" />
 
-	<issue id="ObsoleteLintCustomCheck">
-		<!-- This should go away once on AGP 7.x.
-		     > Lint found an issue registry (androidx.appcompat.AppCompatIssueRegistry) which requires a newer API level.
-		     > That means that the custom lint checks are intended for a newer lint version; please upgrade
-		-->
-		<ignore regexp="`androidx\.appcompat\.AppCompatIssueRegistry`" />
-	</issue>
-
 	<issue id="UnusedResources">
 		<!-- Used by *ScreenshotTest via PaparazziCoat. -->
 		<ignore regexp="`R.style.AppTheme_ScreenshotTest`" />

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,15 +30,15 @@ pluginManagement {
 				includeGroup("gradle.plugin.org.gradle.android")
 			}
 		}
-		maven("https://s01.oss.sonatype.org/content/repositories/snapshots/") {
-			name = "Sonatype 01: SNAPSHOTs"
-			content {
-				includeGroup("net.twisterrob.gradle")
-			}
-			mavenContent {
-				snapshotsOnly()
-			}
-		}
+		//maven("https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+		//	name = "Sonatype 01: SNAPSHOTs"
+		//	content {
+		//		includeGroup("net.twisterrob.gradle")
+		//	}
+		//	mavenContent {
+		//		snapshotsOnly()
+		//	}
+		//}
 	}
 	resolutionStrategy {
 		eachPlugin {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,9 +15,21 @@ includeBuild("gradle/plugins")
 
 pluginManagement {
 	repositories {
-		google()
+		google {
+			content {
+				includeGroupByRegex("""^com\.android(\..*)?$""")
+				includeGroupByRegex("""^com\.google\..*$""")
+				includeGroupByRegex("""^androidx\..*$""")
+			}
+		}
 		mavenCentral()
-		gradlePluginPortal()
+		gradlePluginPortal {
+			content {
+				includeGroup("com.gradle")
+				includeGroup("com.gradle.enterprise")
+				includeGroup("gradle.plugin.org.gradle.android")
+			}
+		}
 		//maven { name = "Sonatype SNAPSHOTs s01"; setUrl("https://s01.oss.sonatype.org/content/repositories/snapshots/") }
 	}
 	resolutionStrategy {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,7 +30,15 @@ pluginManagement {
 				includeGroup("gradle.plugin.org.gradle.android")
 			}
 		}
-		//maven { name = "Sonatype SNAPSHOTs s01"; setUrl("https://s01.oss.sonatype.org/content/repositories/snapshots/") }
+		maven("https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+			name = "Sonatype 01: SNAPSHOTs"
+			content {
+				includeGroup("net.twisterrob.gradle")
+			}
+			mavenContent {
+				snapshotsOnly()
+			}
+		}
 	}
 	resolutionStrategy {
 		eachPlugin {


### PR DESCRIPTION
Fixes #8

Note: Fixed in AGP 7.1.0 https://issuetracker.google.com/issues/195025261
> Unable to detect AGP versions for included builds. All projects in the build should use the same AGP version. Class name for the included build object: org.gradle.composite.internal.DefaultIncludedBuild$IncludedBuildImpl_Decorated.
