### PR TITLE
CI: Replace ::set-output with GITHUB_OUTPUT

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -91,9 +91,16 @@ gradleEnterprise {
 		// TODO how to use net.twisterrob.sun.plugins.isCI? 
 		if (System.getenv("GITHUB_ACTIONS") == "true") {
 			val setOutput = File(System.getenv("GITHUB_OUTPUT"))
+			println("File (${System.getenv("GITHUB_OUTPUT")}: ${setOutput.absolutePath}")
 			buildScanPublished {
+				println("Before")
+				println(setOutput.readText())
 				setOutput.appendText("build-scan-url=${toJson(buildScanUri.toString())}")
+				println("Halfway")
+				println(setOutput.readText())
 				setOutput.appendText("something=else\n")
+				println("After")
+				println(setOutput.readText())
 			}
 			gradle.addBuildListener(object : BuildAdapter() {
 				@Deprecated("Won't work with configuration caching.")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -92,7 +92,8 @@ gradleEnterprise {
 		if (System.getenv("GITHUB_ACTIONS") == "true") {
 			val setOutput = File(System.getenv("GITHUB_OUTPUT"))
 			buildScanPublished {
-				setOutput.appendText("build-scan-url=${toJson(this@buildScanPublished.buildScanUri.toString())}\n")
+				setOutput.appendText("build-scan-url=${toJson(this@buildScanPublished.buildScanUri.toString())}")
+				setOutput.appendText("something=else\n")
 			}
 			gradle.addBuildListener(object : BuildAdapter() {
 				@Deprecated("Won't work with configuration caching.")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -90,15 +90,21 @@ gradleEnterprise {
 		termsOfServiceAgree = "yes"
 		// TODO how to use net.twisterrob.sun.plugins.isCI? 
 		if (System.getenv("GITHUB_ACTIONS") == "true") {
-			val setOutput = File(System.getenv("GITHUB_OUTPUT"))
+			fun setOutput(name: String, value: Any?) {
+				// Using `appendText` to make sure out outputs are not cleared.
+				// Using `\n` to make sure further outputs are correct.
+				// Using `toJson()` to ensure that any special characters (such as newlines) are escaped.
+				File(System.getenv("GITHUB_OUTPUT")).appendText("${name}=${toJson(value)}\n")
+			}
+
 			buildScanPublished {
-				setOutput.appendText("build-scan-url=${toJson(buildScanUri)}\n")
+				setOutput("build-scan-url", buildScanUri)
 			}
 			gradle.addBuildListener(object : BuildAdapter() {
 				@Deprecated("Won't work with configuration caching.")
 				override fun buildFinished(result: BuildResult) {
-					setOutput.appendText("result-success=${toJson(result.failure == null)}\n")
-					setOutput.appendText("result-text=${toJson(resultText(result))}\n")
+					setOutput("result-success", result.failure == null)
+					setOutput("result-text", resultText(result))
 				}
 
 				private fun resultText(result: BuildResult): String =

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -91,16 +91,8 @@ gradleEnterprise {
 		// TODO how to use net.twisterrob.sun.plugins.isCI? 
 		if (System.getenv("GITHUB_ACTIONS") == "true") {
 			val setOutput = File(System.getenv("GITHUB_OUTPUT"))
-			println("File (${System.getenv("GITHUB_OUTPUT")}: ${setOutput.absolutePath}")
 			buildScanPublished {
-				println("Before")
-				println(setOutput.readText())
-				setOutput.appendText("build-scan-url=${toJson(buildScanUri.toString())}")
-				println("Halfway")
-				println(setOutput.readText())
-				setOutput.appendText("something=else\n")
-				println("After")
-				println(setOutput.readText())
+				setOutput.appendText("build-scan-url=${toJson(buildScanUri)}\n")
 			}
 			gradle.addBuildListener(object : BuildAdapter() {
 				@Deprecated("Won't work with configuration caching.")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -92,7 +92,7 @@ gradleEnterprise {
 		if (System.getenv("GITHUB_ACTIONS") == "true") {
 			val setOutput = File(System.getenv("GITHUB_OUTPUT"))
 			buildScanPublished {
-				setOutput.appendText("build-scan-url=${toJson(this@buildScanPublished.buildScanUri.toString())}")
+				setOutput.appendText("build-scan-url=${toJson(buildScanUri.toString())}")
 				setOutput.appendText("something=else\n")
 			}
 			gradle.addBuildListener(object : BuildAdapter() {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -98,7 +98,7 @@ gradleEnterprise {
 			}
 
 			buildScanPublished {
-				setOutput("build-scan-url", buildScanUri)
+				setOutput("build-scan-url", buildScanUri.toASCIIString())
 			}
 			gradle.addBuildListener(object : BuildAdapter() {
 				@Deprecated("Won't work with configuration caching.")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -90,14 +90,15 @@ gradleEnterprise {
 		termsOfServiceAgree = "yes"
 		// TODO how to use net.twisterrob.sun.plugins.isCI? 
 		if (System.getenv("GITHUB_ACTIONS") == "true") {
+			val setOutput = File(System.getenv("GITHUB_OUTPUT"))
 			buildScanPublished {
-				println("::set-output name=build-scan-url::${toJson(this@buildScanPublished.buildScanUri.toString())}")
+				setOutput.appendText("build-scan-url=${toJson(this@buildScanPublished.buildScanUri.toString())}\n")
 			}
 			gradle.addBuildListener(object : BuildAdapter() {
 				@Deprecated("Won't work with configuration caching.")
 				override fun buildFinished(result: BuildResult) {
-					println("::set-output name=result-success::${toJson(result.failure == null)}")
-					println("::set-output name=result-text::${toJson(resultText(result))}")
+					setOutput.appendText("result-success=${toJson(result.failure == null)}\n")
+					setOutput.appendText("result-text=${toJson(resultText(result))}\n")
 				}
 
 				private fun resultText(result: BuildResult): String =


### PR DESCRIPTION
Fix `set-output` deprecation https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ using https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

Notes:
 * Strangely there's actually no deprecation, probably because this is not an action, just CI. They might've deprecated actions using `::set-output`, but not .yml workflows yet.
 * newlines are mandatory if you want multiple outputs.
 * quotes (") are parsed, so `a="b"` means `a` will just contain `b` not `"b"` when read.
 * quotes (") are parsed, so anything after `a="b"c=d` is ignored, so `a` will just contain `b` when read.
 * This behavior probably didn't change much from `::set-output`.

| | Before | After |
|-|-|-|
|Logs|https://github.com/TWiStErRob/net.twisterrob.sun/actions/runs/3272501934/jobs/5383585963 ![image](https://user-images.githubusercontent.com/2906988/196404933-676c9718-8645-4dfa-9b5f-668060aa6d09.png)| https://github.com/TWiStErRob/net.twisterrob.sun/actions/runs/3272547163/jobs/5383689163 ![image](https://user-images.githubusercontent.com/2906988/196405667-4f83f3d4-3ddf-4602-8653-28412ebc505f.png)|
|Output|https://gradle.com/s/tqtjum5sec2ps ![image](https://user-images.githubusercontent.com/2906988/196405060-5c1da2b0-f865-4a2a-b97c-4a7561dffa0d.png) | same |