### PR TITLE
compileSdk 33 to 34 (including paparazzi 1.3.0 to 1.3.1 and removed guava workaround)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,8 +33,8 @@ jobs:
           # sdkmanager --install "platform-tools"
 
           # Install Android API used to build the project.
-          echo sdkmanager --install "platforms;android-33"
-          sdkmanager --install "platforms;android-33"
+          echo sdkmanager --install "platforms;android-34"
+          sdkmanager --install "platforms;android-34"
 
       - name: Checkout ${{ github.ref }} branch in ${{ github.repository }} repository.
         uses: actions/checkout@v4
@@ -176,8 +176,8 @@ jobs:
           # sdkmanager --install "platform-tools"
 
           # Install Android API used to build the project.
-          echo sdkmanager --install "platforms;android-33"
-          sdkmanager --install "platforms;android-33"
+          echo sdkmanager --install "platforms;android-34"
+          sdkmanager --install "platforms;android-34"
 
       - name: Checkout ${{ needs.pull_request.outputs.base_ref }} branch in ${{ github.repository }} repository.
         uses: actions/checkout@v4
@@ -272,8 +272,8 @@ jobs:
           # sdkmanager --install "platform-tools"
 
           # Install Android API used to build the project.
-          echo sdkmanager --install "platforms;android-33"
-          sdkmanager --install "platforms;android-33"
+          echo sdkmanager --install "platforms;android-34"
+          sdkmanager --install "platforms;android-34"
 
       - name: Checkout ${{ needs.pull_request.outputs.head_ref }} branch in ${{ github.repository }} repository.
         uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -326,8 +326,8 @@ jobs:
           path: |
             ${{ github.workspace }}/**/build/reports/tests/*/
             ${{ github.workspace }}/**/build/test-results/*/TEST-*.xml
-            ${{ github.workspace }}/**/out/failures/delta-*.png
-            ${{ github.workspace }}/**/out/failures/*.png
+            ${{ github.workspace }}/**/build/paparazzi/failures/delta-*.png
+            ${{ github.workspace }}/**/build/paparazzi/failures/*.png
 
       - name: Publish "Screenshot Verify Results" check suite.
         if: success() || failure()

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,5 @@
 /temp
 gradled.bat
 
-# verifyPaparazzi output
-**/out/failures/delta-net.twisterrob.sun.*.png
-**/out/failures/net.twisterrob.sun.*.png
 # recordPaparazzi output (see https://github.com/cashapp/paparazzi/pull/310)
 **/src/test/snapshots/

--- a/component/paparazzi/build.gradle.kts
+++ b/component/paparazzi/build.gradle.kts
@@ -4,12 +4,6 @@ plugins {
 
 dependencies {
 	api(libs.test.paparazzi)
-	api(libs.guava.jre) {
-		because(
-			"Help Gradle select the Guava -jre flavor instead of -android. "
-				+ "See https://github.com/cashapp/paparazzi/issues/906."
-		)
-	}
 	api(libs.test.junit4)
 	api(libs.test.mockito)
 	api(libs.test.paramInjector)

--- a/component/paparazzi/src/main/java/net/twisterrob/sun/test/screenshots/PaparazziFactory.kt
+++ b/component/paparazzi/src/main/java/net/twisterrob/sun/test/screenshots/PaparazziFactory.kt
@@ -6,19 +6,26 @@ import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
 import com.android.ide.common.rendering.api.SessionParams.RenderingMode
 
+/**
+ * Set up Paparazzi for widgets, components, and other small UI elements.
+ */
 fun widgetPaparazzi(): Paparazzi =
 	Paparazzi(
 		theme = "AppTheme.ScreenshotTest",
-		deviceConfig = DeviceConfig.PIXEL_2.copy(softButtons = false),
 		maxPercentDifference = 0.0,
 		appCompatEnabled = false,
+		showSystemUi = false,
 		renderingMode = RenderingMode.SHRINK,
 	)
 
+/**
+ * Set up Paparazzi for Activity tests, which take the full screen (not fullscreen).
+ */
 fun activityPaparazzi(): Paparazzi =
 	Paparazzi(
 		theme = "AppTheme",
 		deviceConfig = DeviceConfig.PIXEL_2,
 		maxPercentDifference = 0.0,
-		appCompatEnabled = true
+		appCompatEnabled = true,
+		showSystemUi = true,
 	)

--- a/component/widget/src/androidTest/java/net/twisterrob/sun/android/test/LocationSpoofer.kt
+++ b/component/widget/src/androidTest/java/net/twisterrob/sun/android/test/LocationSpoofer.kt
@@ -12,6 +12,7 @@ import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.getSystemService
 import androidx.test.platform.app.InstrumentationRegistry
+import net.twisterrob.sun.android.getBestProvider
 import org.jetbrains.annotations.TestOnly
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/component/widget/src/androidTest/java/net/twisterrob/sun/android/test/LocationSpoofer.kt
+++ b/component/widget/src/androidTest/java/net/twisterrob/sun/android/test/LocationSpoofer.kt
@@ -2,7 +2,6 @@ package net.twisterrob.sun.android.test
 
 import android.app.AppOpsManager
 import android.content.Context
-import android.location.Criteria
 import android.location.Location
 import android.location.LocationManager
 import android.location.provider.ProviderProperties
@@ -129,11 +128,7 @@ class LocationSpoofer(
 		val providers = locationManager.allProviders.joinToString(separator = "\n") {
 			"$it(${locationManager.isProviderEnabled(it)}):${locationManager.getProviderProperties(it).toString()}"
 		}
-		val criteria = Criteria().apply {
-			accuracy = Criteria.ACCURACY_COARSE
-			powerRequirement = Criteria.POWER_LOW
-		}
-		val bestProvider = locationManager.getBestProvider(criteria, true) ?: LocationManager.PASSIVE_PROVIDER
+		val bestProvider = locationManager.getBestProvider() ?: LocationManager.PASSIVE_PROVIDER
 		val last = locationManager.getLastKnownLocation(bestProvider)
 		val lastPassive = locationManager.getLastKnownLocation(LocationManager.PASSIVE_PROVIDER)
 		@Suppress("ForbiddenMethodCall", "NullableToStringCall")

--- a/component/widget/src/main/java/net/twisterrob/sun/android/LocationRetriever.kt
+++ b/component/widget/src/main/java/net/twisterrob/sun/android/LocationRetriever.kt
@@ -142,8 +142,9 @@ class LocationRetriever @Inject constructor(
 	}
 }
 
+// REPORT should be internal, but it's a compile error in androidTest, friends/associateWith not set in AGP?
 @Suppress("DEPRECATION") // TODEL https://github.com/TWiStErRob/net.twisterrob.sun/issues/302
-internal fun LocationManager.getBestProvider(): String? {
+fun LocationManager.getBestProvider(): String? {
 	val criteria = android.location.Criteria().apply {
 		accuracy = android.location.Criteria.ACCURACY_COARSE
 		powerRequirement = android.location.Criteria.POWER_LOW

--- a/component/widget/src/main/java/net/twisterrob/sun/android/LocationRetriever.kt
+++ b/component/widget/src/main/java/net/twisterrob/sun/android/LocationRetriever.kt
@@ -94,16 +94,10 @@ class LocationRetriever @Inject constructor(
 				return
 			}
 		}
-		@Suppress("DEPRECATION") // TODEL https://github.com/TWiStErRob/net.twisterrob.sun/issues/302
-		val criteria = android.location.Criteria().apply {
-			accuracy = android.location.Criteria.ACCURACY_COARSE
-			powerRequirement = android.location.Criteria.POWER_LOW
-		}
-		val provider = @Suppress("DEPRECATION") this.getBestProvider(criteria, true)
-			?: LocationManager.PASSIVE_PROVIDER
+		val provider = this.getBestProvider() ?: LocationManager.PASSIVE_PROVIDER
 		this.getLastKnownLocation(provider)?.let { location ->
 			if (Log.isLoggable(TAG, Log.VERBOSE)) {
-				Log.v(TAG, "${this} found cached location in best (${criteria}) provider: ${provider}, $location")
+				Log.v(TAG, "${this} found cached location in best provider: ${provider}, $location")
 			}
 			callback.cachedLocation(location)
 			return
@@ -146,4 +140,13 @@ class LocationRetriever @Inject constructor(
 
 		private const val TAG = "Sun"
 	}
+}
+
+@Suppress("DEPRECATION") // TODEL https://github.com/TWiStErRob/net.twisterrob.sun/issues/302
+internal fun LocationManager.getBestProvider(): String? {
+	val criteria = android.location.Criteria().apply {
+		accuracy = android.location.Criteria.ACCURACY_COARSE
+		powerRequirement = android.location.Criteria.POWER_LOW
+	}
+	return getBestProvider(criteria, true)
 }

--- a/component/widget/src/main/java/net/twisterrob/sun/android/LocationRetriever.kt
+++ b/component/widget/src/main/java/net/twisterrob/sun/android/LocationRetriever.kt
@@ -3,7 +3,6 @@ package net.twisterrob.sun.android
 import android.Manifest.permission.ACCESS_COARSE_LOCATION
 import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.content.Context
-import android.location.Criteria
 import android.location.Location
 import android.location.LocationManager
 import android.util.Log
@@ -95,11 +94,13 @@ class LocationRetriever @Inject constructor(
 				return
 			}
 		}
-		val criteria = Criteria().apply {
-			accuracy = Criteria.ACCURACY_COARSE
-			powerRequirement = Criteria.POWER_LOW
+		@Suppress("DEPRECATION") // TODEL https://github.com/TWiStErRob/net.twisterrob.sun/issues/302
+		val criteria = android.location.Criteria().apply {
+			accuracy = android.location.Criteria.ACCURACY_COARSE
+			powerRequirement = android.location.Criteria.POWER_LOW
 		}
-		val provider = this.getBestProvider(criteria, true) ?: LocationManager.PASSIVE_PROVIDER
+		val provider = @Suppress("DEPRECATION") this.getBestProvider(criteria, true)
+			?: LocationManager.PASSIVE_PROVIDER
 		this.getLastKnownLocation(provider)?.let { location ->
 			if (Log.isLoggable(TAG, Log.VERBOSE)) {
 				Log.v(TAG, "${this} found cached location in best (${criteria}) provider: ${provider}, $location")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,8 +58,6 @@ kotlin-detekt-libraries = { module = "io.gitlab.arturbosch.detekt:detekt-rules-l
 dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
 
-guava-jre = { module = "com.google.guava:guava", version = "32.0.1-jre" }
-
 test-paparazzi = { module = "app.cash.paparazzi:paparazzi", version.ref = "paparazzi" }
 test-paparazziGradle = { module = "app.cash.paparazzi:app.cash.paparazzi.gradle.plugin", version.ref = "paparazzi" }
 test-junit4 = { module = "junit:junit", version = "4.13.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 java = "17"
 
 # TODO When changing this, update CI too (platforms;android-xx).
-compileSdkVersion = "33"
+compileSdkVersion = "34"
 minSdkVersion = "14"
 targetSdkVersion = "33"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,8 +27,7 @@ dagger = "2.48"
 # Changelog (4.x and 5.x): https://github.com/mockito/mockito/releases
 mockito = "5.5.0"
 
-#noinspection GradleDependency
-paparazzi = "1.3.0"
+paparazzi = "1.3.1"
 
 test-jsonAssert = "1.5.1"
 

--- a/gradle/plugins/src/main/kotlin/net/twisterrob/sun/plugins/PaparazziPlugin.kt
+++ b/gradle/plugins/src/main/kotlin/net/twisterrob/sun/plugins/PaparazziPlugin.kt
@@ -16,11 +16,6 @@ public class PaparazziPlugin : Plugin<Project> {
 			"testImplementation"(target.project(":component:paparazzi"))
 		}
 
-		// TODEL workaround for https://github.com/cashapp/paparazzi/issues/446
-		target.tasks.named<Delete>("clean") {
-			delete(project.file("out/failures"))
-		}
-
 		target.tasks.withType<Test>().configureEach {
 			useJUnit {
 				if (project.property("net.twisterrob.build.screenshot-tests").toString().toBoolean()) {


### PR DESCRIPTION
 * Fixes https://github.com/TWiStErRob/net.twisterrob.sun/pull/274
 * Closes https://github.com/TWiStErRob/net.twisterrob.sun/pull/268