### PR TITLE
Fix compileSdk 34 tests

### DIFF
--- a/component/paparazzi/build.gradle.kts
+++ b/component/paparazzi/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-	id("project-module-java-library")
+	id("project-module-android-library")
 }
 
 dependencies {
@@ -8,3 +8,6 @@ dependencies {
 	api(libs.test.mockito)
 	api(libs.test.paramInjector)
 }
+
+// See https://github.com/cashapp/paparazzi/issues/1025#issuecomment-1687437843.
+android.compileSdk = 33

--- a/component/paparazzi/src/main/java/net/twisterrob/sun/test/screenshots/PaparazziFactory.kt
+++ b/component/paparazzi/src/main/java/net/twisterrob/sun/test/screenshots/PaparazziFactory.kt
@@ -3,7 +3,9 @@
 package net.twisterrob.sun.test.screenshots
 
 import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Environment
 import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.detectEnvironment
 import com.android.ide.common.rendering.api.SessionParams.RenderingMode
 
 /**
@@ -16,6 +18,7 @@ fun widgetPaparazzi(): Paparazzi =
 		appCompatEnabled = false,
 		showSystemUi = false,
 		renderingMode = RenderingMode.SHRINK,
+		environment = env(),
 	)
 
 /**
@@ -28,4 +31,16 @@ fun activityPaparazzi(): Paparazzi =
 		maxPercentDifference = 0.0,
 		appCompatEnabled = true,
 		showSystemUi = true,
+		environment = env(),
 	)
+
+/**
+ * See https://github.com/cashapp/paparazzi/issues/1025#issuecomment-1654065507.
+ */
+private fun env(): Environment =
+	detectEnvironment().run {
+		copy(
+			compileSdkVersion = 33,
+			platformDir = platformDir.replace("android-34", "android-33")
+		)
+	}

--- a/component/paparazzi/src/main/java/net/twisterrob/sun/test/screenshots/PaparazziFactory.kt
+++ b/component/paparazzi/src/main/java/net/twisterrob/sun/test/screenshots/PaparazziFactory.kt
@@ -36,6 +36,7 @@ fun activityPaparazzi(): Paparazzi =
 
 /**
  * See https://github.com/cashapp/paparazzi/issues/1025#issuecomment-1654065507.
+ * TODO when changing this, update also `android.compileSdk` build.gradle.
  */
 private fun env(): Environment =
 	detectEnvironment().run {

--- a/config/lint/baseline/lint_baseline-component+paparazzi.xml
+++ b/config/lint/baseline/lint_baseline-component+paparazzi.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.1.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.1.1)" variant="all" version="8.1.1">
+
+    <issue
+        id="DiscouragedPrivateApi"
+        message="Reflective access to IActivityManagerSingleton, which is not part of the public SDK and therefore likely to change in future Android releases"
+        errorLine1="    ActivityManager::class.java"
+        errorLine2="    ^">
+        <location
+            file="src/main/java/net/twisterrob/sun/test/screenshots/ActivityManagerSingletonHack.kt"
+            line="77"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `javax.naming.directory`. Referenced from `org.bouncycastle.cert.dane.fetcher.JndiDANEFetcherFactory`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/org.bouncycastle/bcpkix-jdk15on/1.67/5f48020a2a60a8d6bcbecceca23529d225b28efb/bcpkix-jdk15on-1.67.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `javax.naming`. Referenced from `org.bouncycastle.cert.dane.fetcher.JndiDANEFetcherFactory.1`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/org.bouncycastle/bcpkix-jdk15on/1.67/5f48020a2a60a8d6bcbecceca23529d225b28efb/bcpkix-jdk15on-1.67.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in com.android.tools:common; not included in Android: `javax.management`. Referenced from `com.android.utils.JvmWideVariable`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/com.android.tools/common/31.0.2/e78240c4a0e406eaa2bb6d6aa633c7cd4c8a5866/common-31.0.2.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `java.awt.color`. Referenced from `com.android.ddmlib.RawImage`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/com.android.tools.ddms/ddmlib/31.0.2/4841ca3d8fb995267eea0e73e812f1c76025a09e/ddmlib-31.0.2.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `javax.naming.ldap`. Referenced from `org.apache.http.conn.ssl.DefaultHostnameVerifier`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/org.apache.httpcomponents/httpclient/4.5.6/1afe5621985efe90a92d0fbc9be86271efbe796f/httpclient-4.5.6.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `javax.imageio.stream`. Referenced from `com.sun.xml.bind.v2.model.impl.RuntimeBuiltinLeafInfoImpl.10`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/org.glassfish.jaxb/jaxb-runtime/2.3.2/5528bc882ea499a09d720b42af11785c4fc6be2a/jaxb-runtime-2.3.2.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `javax.xml.bind.annotation.adapters`. Referenced from `com.sun.xml.bind.v2.model.impl.ClassInfoImpl`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/org.glassfish.jaxb/jaxb-runtime/2.3.2/5528bc882ea499a09d720b42af11785c4fc6be2a/jaxb-runtime-2.3.2.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `javax.sound.sampled`. Referenced from `org.jcodec.common.SoundUtil`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/org.jcodec/jcodec-javase/0.2.5/924491879d101f60f659c0a26562b3c232f1c59d/jcodec-javase-0.2.5.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `java.awt.datatransfer`. Referenced from `com.sun.jna.platform.dnd.DragHandler`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/net.java.dev.jna/jna-platform/5.6.0/d18424ffb8bbfd036d71bcaab9b546858f2ef986/jna-platform-5.6.0.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `java.awt.dnd`. Referenced from `com.sun.jna.platform.dnd.DragHandler`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/net.java.dev.jna/jna-platform/5.6.0/d18424ffb8bbfd036d71bcaab9b546858f2ef986/jna-platform-5.6.0.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `javax.swing.text`. Referenced from `com.sun.jna.platform.dnd.DragHandler`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/net.java.dev.jna/jna-platform/5.6.0/d18424ffb8bbfd036d71bcaab9b546858f2ef986/jna-platform-5.6.0.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `javax.swing`. Referenced from `com.sun.jna.platform.WindowUtils.MacWindowUtils`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/net.java.dev.jna/jna-platform/5.6.0/d18424ffb8bbfd036d71bcaab9b546858f2ef986/jna-platform-5.6.0.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in app.cash.paparazzi:layoutlib-native-jdk11; not included in Android: `java.awt.event`. Referenced from `com.android.layoutlib.bridge.impl.RenderSessionImpl`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/app.cash.paparazzi/layoutlib-native-jdk11/2022.2.1-5128371-2/985a1fedfcbcfa18694728949bcfebd3903cfd9b/layoutlib-native-jdk11-2022.2.1-5128371-2.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in org.mockito:mockito-core; not included in Android: `java.lang.instrument`. Referenced from `org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/org.mockito/mockito-core/5.5.0/1660ec3ce0af7f713af923817b225a37cc5cf965/mockito-core-5.5.0.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in app.cash.paparazzi:paparazzi; not included in Android: `java.awt.image`. Referenced from `app.cash.paparazzi.HtmlReportWriter`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/app.cash.paparazzi/paparazzi/1.3.1/2f48134f87bf7542ff3adb30a8f150f4dda54afa/paparazzi-1.3.1.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in app.cash.paparazzi:paparazzi; not included in Android: `java.awt`. Referenced from `app.cash.paparazzi.Paparazzi`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/app.cash.paparazzi/paparazzi/1.3.1/2f48134f87bf7542ff3adb30a8f150f4dda54afa/paparazzi-1.3.1.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in app.cash.paparazzi:paparazzi; not included in Android: `javax.imageio`. Referenced from `app.cash.paparazzi.HtmlReportWriter`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/app.cash.paparazzi/paparazzi/1.3.1/2f48134f87bf7542ff3adb30a8f150f4dda54afa/paparazzi-1.3.1.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `javax.xml.bind.annotation`. Referenced from `com.android.repository.api.SchemaModule.SchemaModuleVersion`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/com.android.tools/repository/31.0.2/c9facaca740e41683fc978551b909da1f6ed211b/repository-31.0.2.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in com.android.tools:sdk-common; not included in Android: `java.awt.geom`. Referenced from `com.android.ide.common.vectordrawable.EllipseSolver`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/com.android.tools/sdk-common/31.0.2/578e46520c75b415184b9c5bf45f7414f17b286a/sdk-common-31.0.2.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in library; not included in Android: `java.lang.management`. Referenced from `com.android.tools.analytics.CommonMetricsData`.">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/com.android.tools.analytics-library/shared/31.0.2/7552ea5c8af6a8a256c66fbebf00c868394a253d/shared-31.0.2.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/org.bouncycastle/bcpkix-jdk15on/1.67/5f48020a2a60a8d6bcbecceca23529d225b28efb/bcpkix-jdk15on-1.67.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/org.bouncycastle/bcpkix-jdk15on/1.67/5f48020a2a60a8d6bcbecceca23529d225b28efb/bcpkix-jdk15on-1.67.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkServerTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="Z:/caches/gradle/caches/modules-2/files-2.1/org.bouncycastle/bcpkix-jdk15on/1.67/5f48020a2a60a8d6bcbecceca23529d225b28efb/bcpkix-jdk15on-1.67.jar"/>
+    </issue>
+
+</issues>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ dagger = "2.48"
 # Changelog (4.x and 5.x): https://github.com/mockito/mockito/releases
 mockito = "5.5.0"
 
+# TODO when upgrading to a version with compileSdk 34 is supported, remove env() method from PaparazziFactory.
 paparazzi = "1.3.1"
 
 test-jsonAssert = "1.5.1"


### PR DESCRIPTION
 * Fixes https://github.com/TWiStErRob/net.twisterrob.sun/pull/301 introduced issues.

Not all the failing tests were because of the mismatch in image size.

```
java.lang.NumberFormatException: Color value '/usr/local/lib/android/sdk/platforms/android-34/data/res/color/system_bar_background_semi_transparent.xml' has wrong size. Format is either#AARRGGBB, #RRGGBB, #RGB, or #ARGB
	at com.android.layoutlib.bridge.impl.ResourceHelper.getColor(ResourceHelper.java:136)
	at android.content.res.Resources_Delegate.getColor(Resources_Delegate.java:221)
	at android.content.res.Resources.getColor(Resources.java:1065)
	at com.android.internal.policy.DecorView.<init>(DecorView.java:313)
	at com.android.internal.policy.PhoneWindow.generateDecor(PhoneWindow.java:2385)
	at com.android.internal.policy.PhoneWindow.installDecor(PhoneWindow.java:2727)
	at com.android.internal.policy.PhoneWindow.getDecorView(PhoneWindow.java:2144)
	at androidx.appcompat.app.AppCompatActivity.initViewTreeOwners(AppCompatActivity.java:221)
	at androidx.appcompat.app.AppCompatActivity.setContentView(AppCompatActivity.java:196)
	at net.twisterrob.sun.android.SunAngleWidgetConfiguration.onCreate(SunAngleWidgetConfiguration.java:144)
	at android.app.Activity.onCreate(Activity.java:1708)
	at net.twisterrob.sun.android.SunAngleWidgetConfigurationScreenshotTest.setUp(SunAngleWidgetConfigurationScreenshotTest.java:57)
```