### PR TITLE
Replace com.gradle.enterprise with com.gradle.develocity

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,7 +39,7 @@ pluginManagement {
 		gradlePluginPortal {
 			content {
 				includeGroup("com.gradle")
-				includeGroup("com.gradle.enterprise")
+				includeGroup("com.gradle.develocity")
 				includeGroup("gradle.plugin.org.gradle.android")
 				includeGroup("org.jetbrains.kotlin.android")
 				includeGroup("io.gitlab.arturbosch.detekt")
@@ -49,15 +49,15 @@ pluginManagement {
 }
 
 plugins {
-	id("com.gradle.enterprise") version "3.17"
+	id("com.gradle.develocity") version "3.17"
 	id("net.twisterrob.gradle.plugin.nagging") version "0.16"
 	id("project-settings")
 }
 
-gradleEnterprise {
+develocity {
 	buildScan {
-		termsOfServiceUrl = "https://gradle.com/terms-of-service"
-		termsOfServiceAgree = "yes"
+		termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+		termsOfUseAgree = "yes"
 		if (isCI) {
 			fun setOutput(name: String, value: Any?) {
 				// Using `appendText` to make sure out outputs are not cleared.


### PR DESCRIPTION
```
w: file:///home/runner/work/net.twisterrob.sun/net.twisterrob.sun/settings.gradle.kts:57:1: 'gradleEnterprise((GradleEnterpriseExtension.() -> Unit)?): Unit' is deprecated. since 3.17

Error: WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin:
- The deprecated "gradleEnterprise.buildScan.termsOfServiceUrl" API has been replaced by "develocity.buildScan.termsOfUseUrl"
- The deprecated "gradleEnterprise.buildScan.termsOfServiceAgree" API has been replaced by "develocity.buildScan.termsOfUseAgree"
- The deprecated "gradleEnterprise.buildScan.buildScanPublished" API has been replaced by "develocity.buildScan.buildScanPublished"
- The "com.gradle.enterprise" plugin has been replaced by "com.gradle.develocity"
```