### PR TITLE
Fix lint warning TrustAllX509TrustManager, it was baselined already

### DIFF
--- a/config/lint/baseline/lint_baseline-component+paparazzi.xml
+++ b/config/lint/baseline/lint_baseline-component+paparazzi.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.4.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.4.1)" variant="all" version="8.4.1">
+<issues format="6" by="lint 8.6.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.6.0)" variant="all" version="8.6.0">
 
     <issue
         id="DiscouragedPrivateApi"
@@ -157,6 +157,13 @@
         message="Invalid package reference in library; not included in Android: `java.lang.management`. Referenced from `com.android.tools.analytics.CommonMetricsData`.">
         <location
             file="/home/runner/.gradle/caches/modules-2/files-2.1/com.android.tools.analytics-library/shared/31.3.2/19dcfacddf50f8e012524b4576dfc6b51bd8b20a/shared-31.3.2.jar"/>
+    </issue>
+
+    <issue
+        id="TrustAllX509TrustManager"
+        message="`checkClientTrusted` is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers">
+        <location
+            file="/home/runner/.gradle/caches/modules-2/files-2.1/org.bouncycastle/bcpkix-jdk15on/1.67/5f48020a2a60a8d6bcbecceca23529d225b28efb/bcpkix-jdk15on-1.67.jar"/>
     </issue>
 
     <issue


### PR DESCRIPTION
https://github.com/TWiStErRob/net.twisterrob.sun/security/code-scanning/323

Report duplicate, the same issue exists just above the insertion.