### PR TITLE
Update Android minSdk from 21 to 23

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 java = "17"
 
 compileSdkVersion = "36"
-minSdkVersion = "21"
+minSdkVersion = "23"
 targetSdkVersion = "35"
 
 # Compatibility: https://developer.android.com/studio/releases/gradle-plugin#updating-gradle


### PR DESCRIPTION
Required for #612 

```
Caused by: java.lang.RuntimeException: Manifest merger failed : uses-sdk:minSdkVersion 21 cannot be smaller than version 23 declared in library [androidx.activity:activity:1.12.1] /home/runner/.gradle/caches/9.2.1/transforms/fe6691070caf925c2e46c6222c51f37f/transformed/activity-1.12.1/AndroidManifest.xml as the library might be using APIs not available in 21
	Suggestion: use a compatible library with a minSdk of at most 21,
		or increase this project's minSdk version to at least 23,
		or use tools:overrideLibrary="androidx.activity" to force usage (may lead to runtime failures)
```