### PR TITLE
Raise Android compileSdk from 36 to 37

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 java-runtime = "25"
 java-daemon = "21"
 
-compileSdkVersion = "36"
+compileSdkVersion = "37"
 minSdkVersion = "23"
 targetSdkVersion = "35"
 


### PR DESCRIPTION
Required by androidx.core:core-ktx 1.19.0. Separate follow-up to #683; CI validation only.